### PR TITLE
Generalise functions to be N-dimensional

### DIFF
--- a/quagmire/function/function_classes.py
+++ b/quagmire/function/function_classes.py
@@ -87,11 +87,15 @@ class LazyEvaluation(object):
             elif len(args) == 1 and quagmire.mesh.check_object_is_a_q_mesh_and_raise(args[0]):
                 mesh = args[0]
                 return diff_mesh.interpolate(mesh.coords[:,0], mesh.coords[:,1], zdata=dx, **kwargs)
-            else:
+            elif len(args) > 1:
                 xi = np.atleast_1d(args[0])
                 yi = np.atleast_1d(args[1])
                 i, e = diff_mesh.interpolate(xi, yi, zdata=dx, **kwargs)
                 return i
+            else:
+                err_msg = "Invalid number of arguments\n"
+                err_msg += "Input a valid mesh or coordinates in x,y directions"
+                raise ValueError(err_msg)
 
         def new_fn_y(*args, **kwargs):
             local_array = self.evaluate(diff_mesh)
@@ -103,11 +107,15 @@ class LazyEvaluation(object):
             elif len(args) == 1 and quagmire.mesh.check_object_is_a_q_mesh_and_raise(args[0]):
                 mesh = args[0]
                 return diff_mesh.interpolate(mesh.coords[:,0], mesh.coords[:,1], zdata=dy, **kwargs)
-            else:
+            elif len(args) > 1:
                 xi = np.atleast_1d(args[0])  # .resize(-1,1)
                 yi = np.atleast_1d(args[1])  # .resize(-1,1)
                 i, e = diff_mesh.interpolate(xi, yi, zdata=dy, **kwargs)
                 return i
+            else:
+                err_msg = "Invalid number of arguments\n"
+                err_msg += "Input a valid mesh or coordinates in x,y directions"
+                raise ValueError(err_msg)
 
         def new_fn_z(*args, **kwargs):
             local_array = self.evaluate(diff_mesh)
@@ -119,11 +127,15 @@ class LazyEvaluation(object):
             elif len(args) == 1 and quagmire.mesh.check_object_is_a_q_mesh_and_raise(args[0]):
                 mesh = args[0]
                 return diff_mesh.interpolate(mesh.coords[:,0], mesh.coords[:,1], zdata=dz, **kwargs)
-            else:
+            elif len(args) > 1:
                 xi = np.atleast_1d(args[0])  # .resize(-1,1)
                 yi = np.atleast_1d(args[1])  # .resize(-1,1)
                 i, e = diff_mesh.interpolate(xi, yi, zdata=dz, **kwargs)
                 return i
+            else:
+                err_msg = "Invalid number of arguments\n"
+                err_msg += "Input a valid mesh or coordinates in x,y directions"
+                raise ValueError(err_msg)
 
         # Should this be made into a vector mesh variable ?
         def new_fn_grad(*args, **kwargs):
@@ -140,7 +152,7 @@ class LazyEvaluation(object):
                     result = diff_mesh.interpolate(mesh.coords[:,0], mesh.coords[:,1], zdata=df, **kwargs)
                     df_interp.append(result)
                 return df_interp
-            else:
+            elif len(args) > 1:
                 xi = np.atleast_1d(args[0])  # .resize(-1,1)
                 yi = np.atleast_1d(args[1])  # .resize(-1,1)
                 df_interp = []
@@ -148,6 +160,10 @@ class LazyEvaluation(object):
                     i, e = diff_mesh.interpolate(xi, yi, zdata=df, **kwargs)
                     df_interp.append(i)
                 return df_interp
+            else:
+                err_msg = "Invalid number of arguments\n"
+                err_msg += "Input a valid mesh or coordinates in x,y directions"
+                raise ValueError(err_msg)
 
         newLazyFn_dx = LazyEvaluation(mesh=diff_mesh)
         newLazyFn_dx.evaluate = new_fn_x
@@ -261,7 +277,7 @@ class parameter(LazyEvaluation):
         self.value = value
         return
 
-    def fn_gradient(self, dirn):
+    def fn_gradient(self, dirn=None):
         """Gradients information is not provided by default for lazy evaluation objects:
            it is necessary to implement the gradient method"""
 
@@ -269,11 +285,17 @@ class parameter(LazyEvaluation):
         px.description = "d({})/dX===0.0".format(self.description)
         py = parameter(0.0)
         py.description = "d({})/dY===0.0".format(self.description)
+        pz = parameter(0.0)
+        pz.description = "d({})/dZ===0.0".format(self.description)
 
-        if dirn == 0:
+        p = [px, py, pz]
+
+        if dirn is None:
+            # not sure about dimensions here, a parameter is always 1-d so it should
+            # always return the same derivative
             return px
         else:
-            return py
+            return p[dirn]
 
     def __call__(self, value=None):
         """Set value (X) of this parameter (equivalent to Parameter.value=X)"""

--- a/quagmire/function/math.py
+++ b/quagmire/function/math.py
@@ -108,6 +108,17 @@ def fabs(lazyFn):
 def sqrt(lazyFn):
     return _make_npmath_op(_np.sqrt, "sqrt", lazyFn)
 
+def degrees(lazyFn):
+    return _make_npmath_op(_np.degrees, "180/pi*", lazyFn)
+
+def radians(lazyFn):
+    return _make_npmath_op(_np.radians, "pi/180*", lazyFn)
+
+def rad2deg(lazyFn):
+    return degrees(lazyFn)
+
+def deg2rad(lazyFn):
+    return radians(lazyFn)
 
 
 # grad
@@ -210,11 +221,29 @@ def hypot(*args):
     return newLazyFn
 
 
+def arctan2(*args):
+    """Lazy evaluation of arctan2 operator on N fields"""
+    def _arctan2(lazyFn_list, *args, **kwargs):
+        lazy_ev = []
+        for lazyFn in lazyFn_list:
+            lazy_ev.append( lazyFn.evaluate(*args, **kwargs) )
+        return _np.arctan2(*lazy_ev)
+    lazyFn_list = []
+    lazyFn_description = ""
+    lazyFn_dependency = set()
+    for lazyFn in args:
+        lazyFn_list.append(lazyFn)
+        lazyFn_description += "{},".format(lazyFn.description)
+        lazyFn_dependency.union(lazyFn.dependency_list)
+    lazyFn_description = lazyFn_description[:-1]
+
+    newLazyFn = _LazyEvaluation(mesh=lazyFn._mesh)
+    newLazyFn.evaluate = lambda *args, **kwargs : _arctan2(lazyFn_list, *args, **kwargs)
+    newLazyFn.description = "arctan2({})".format(lazyFn_description)
+    newLazyFn.dependency_list = lazyFn_dependency
+
+    return newLazyFn
+
 ## These are not defined yet (LM)
 
-# arctan2(x1, x2, /[, out, where, casting, …])	Element-wise arc tangent of x1/x2 choosing the quadrant correctly.
-# degrees(x, /[, out, where, casting, order, …])	Convert angles from radians to degrees.
-# radians(x, /[, out, where, casting, order, …])	Convert angles from degrees to radians.
 # unwrap(p[, discont, axis])	Unwrap by changing deltas between values to 2*pi complement.
-# deg2rad(x, /[, out, where, casting, order, …])	Convert angles from degrees to radians.
-# rad2deg(x, /[, out, where, casting, order, …])	Convert angles from radians to degrees.

--- a/quagmire/mesh/pixmesh.py
+++ b/quagmire/mesh/pixmesh.py
@@ -189,6 +189,9 @@ class PixMesh(_CommonMesh):
 
         self.root = False
 
+        # functions / parameters that are required for compatibility among FlatMesh types
+        self._radius = 1.0
+
 
     def derivative_grad(self, PHI):
         """

--- a/quagmire/mesh/strimesh.py
+++ b/quagmire/mesh/strimesh.py
@@ -183,6 +183,9 @@ class sTriMesh(_CommonMesh):
         self.data = self.tri.points
         self.interpolate = self.tri.interpolate
 
+        # functions / parameters that are required for compatibility among FlatMesh types
+        self._derivative_grad_cartesian = self.tri.gradient_xyz
+
 
     def get_local_mesh(self):
         """
@@ -280,14 +283,7 @@ class sTriMesh(_CommonMesh):
         PHIy : ndarray of floats, shape(n,)
             first partial derivative of PHI in y direction
         """
-        PHIx, PHIy, PHIz = self.tri.gradient_xyz(PHI, nit, tol)
-
-        R = self._radius
-
-        PHIx *= R
-        PHIy *= R
-        PHIz *= R
-        return PHIx, PHIy, PHIz
+        return self.tri.gradient_lonlat(PHI, nit, tol)
 
 
     def derivative_div(self, PHIx, PHIy, PHIz, **kwargs):

--- a/quagmire/mesh/trimesh.py
+++ b/quagmire/mesh/trimesh.py
@@ -174,6 +174,10 @@ class TriMesh(_CommonMesh):
         self.data = self.coords
         self.interpolate = self.tri.interpolate
 
+        # functions / parameters that are required for compatibility among FlatMesh types
+        self._derivative_grad_cartesian = self.derivative_grad
+        self._radius = 1.0
+
 
 
     def get_local_mesh(self):

--- a/quagmire/topomesh/topomesh.py
+++ b/quagmire/topomesh/topomesh.py
@@ -56,7 +56,7 @@ class TopoMesh(object):
         self._downhill_neighbours = downhill_neighbours
 
         # Slope (function)
-        self.slope = fn.math.sqrt(self.topography.fn_gradient(0)**2.0+self.topography.fn_gradient(1)**2.0)
+        self.slope = fn.math.hypot(*self.topography.fn_gradient())
 
         self._heightVariable = self.topography
 

--- a/quagmire/topomesh/topomesh.py
+++ b/quagmire/topomesh/topomesh.py
@@ -56,7 +56,7 @@ class TopoMesh(object):
         self._downhill_neighbours = downhill_neighbours
 
         # Slope (function)
-        self.slope = fn.math.hypot(*self.topography.fn_gradient())
+        self.slope = fn.math.slope(self.topography)
 
         self._heightVariable = self.topography
 


### PR DESCRIPTION
Derivatives in `sTriMesh` are in 3 dimensions, which motivates a generalisation of some functions to accept 2 or 3 input arguments.

If no direction is provided to obtain derivatives, i.e.
```python
lazyFn.fn_gradient(dirn=None)
```
then all directional derivatives are returned (as functions).