### PR TITLE
Project I/O

### DIFF
--- a/quagmire/function/__init__.py
+++ b/quagmire/function/__init__.py
@@ -1,4 +1,4 @@
-from .function_classes import *
+from .function_classes import LazyEvaluation, parameter
 from . import math
 from . import misc
 from . import stats

--- a/quagmire/function/function_classes.py
+++ b/quagmire/function/function_classes.py
@@ -51,7 +51,13 @@ class LazyEvaluation(object):
     def evaluate(self, *args, **kwargs):
         raise(NotImplementedError)
 
-    def fn_gradient(self, dirn=None, mesh=None):
+
+    @property
+    def fn_gradient(self):
+        return self._fn_gradient()
+    
+
+    def _fn_gradient(self, dirn=None, mesh=None):
         """
         The generic mechanism for obtaining the gradient of a lazy variable is
         to evaluate the values on the mesh at the time in question and use the mesh gradient
@@ -73,8 +79,6 @@ class LazyEvaluation(object):
         else:
             quagmire.mesh.check_object_is_a_q_mesh_and_raise(mesh)
             diff_mesh = mesh
-
-        ndim = np.shape(diff_mesh.data)[1]
 
         def new_fn_x(*args, **kwargs):
             local_array = self.evaluate(diff_mesh)
@@ -117,26 +121,6 @@ class LazyEvaluation(object):
                 err_msg += "Input a valid mesh or coordinates in x,y directions"
                 raise ValueError(err_msg)
 
-        def new_fn_z(*args, **kwargs):
-            local_array = self.evaluate(diff_mesh)
-            df_tuple = diff_mesh.derivative_grad(local_array, nit=10, tol=1e-8)
-            dz = df_tuple[2]
-
-            if len(args) == 1 and args[0] == diff_mesh:
-                return dz
-            elif len(args) == 1 and quagmire.mesh.check_object_is_a_q_mesh_and_raise(args[0]):
-                mesh = args[0]
-                return diff_mesh.interpolate(mesh.coords[:,0], mesh.coords[:,1], zdata=dz, **kwargs)
-            elif len(args) > 1:
-                xi = np.atleast_1d(args[0])  # .resize(-1,1)
-                yi = np.atleast_1d(args[1])  # .resize(-1,1)
-                i, e = diff_mesh.interpolate(xi, yi, zdata=dz, **kwargs)
-                return i
-            else:
-                err_msg = "Invalid number of arguments\n"
-                err_msg += "Input a valid mesh or coordinates in x,y directions"
-                raise ValueError(err_msg)
-
         # Should this be made into a vector mesh variable ?
         def new_fn_grad(*args, **kwargs):
             local_array = self.evaluate(diff_mesh)
@@ -171,11 +155,8 @@ class LazyEvaluation(object):
         newLazyFn_dy = LazyEvaluation(mesh=diff_mesh)
         newLazyFn_dy.evaluate = new_fn_y
         newLazyFn_dy.description = "d({})/dY".format(self.description)
-        newLazyFn_dz = LazyEvaluation(mesh=diff_mesh)
-        newLazyFn_dz.evaluate = new_fn_z
-        newLazyFn_dz.description = "d({})/dZ".format(self.description)
 
-        fn_dir = [newLazyFn_dx, newLazyFn_dy, newLazyFn_dz][0:ndim]
+        fn_dir = [newLazyFn_dx, newLazyFn_dy]
 
         if dirn is None:
             # return a vector mesh variable ?

--- a/quagmire/function/math.py
+++ b/quagmire/function/math.py
@@ -125,7 +125,7 @@ def deg2rad(lazyFn):
 
 def grad(lazyFn):
     """Lazy evaluation of gradient operator on a scalar field"""
-    return lazyFn.fn_gradient()
+    return lazyFn.fn_gradient
 
 def div(*args):
     """Lazy evaluation of divergence operator on a N-D vector field"""
@@ -142,7 +142,7 @@ def div(*args):
     lazyFn_dependency = set()
     for f, lazyFn in enumerate(args):
         lazyFn_id.add(lazyFn._mesh.id)
-        lazyFn_list.append(lazyFn.fn_gradient(f))
+        lazyFn_list.append(lazyFn.fn_gradient[f])
         lazyFn_description += "diff({},{}) + ".format(lazyFn.description, dims[f])
         lazyFn_dependency.union(lazyFn.dependency_list)
     lazyFn_description = lazyFn_description[:-3]
@@ -166,8 +166,8 @@ def curl(*args):
             raise ValueError("Both meshes must be identical")
         
         newLazyFn = _LazyEvaluation(mesh=lazyFn_x._mesh)
-        fn_dvydx = lazyFn_y.fn_gradient(0)
-        fn_dvxdy = lazyFn_x.fn_gradient(1)
+        fn_dvydx = lazyFn_y.fn_gradient[0]
+        fn_dvxdy = lazyFn_x.fn_gradient[1]
         newLazyFn.evaluate = lambda *args, **kwargs : fn_dvydx.evaluate(*args, **kwargs) - fn_dvxdy.evaluate(*args, **kwargs)
         newLazyFn.description = "diff({},X) - diff({},Y)".format(lazyFn_y.description, lazyFn_x.description)
         newLazyFn.dependency_list = lazyFn_x.dependency_list | lazyFn_y.dependency_list
@@ -180,9 +180,9 @@ def curl(*args):
             raise ValueError("All meshes must be identical")
         
         newLazyFn = _LazyEvaluation(mesh=lazyFn_x._mesh)
-        fn_dvxdx, fn_dvxdy, fn_dvxdz = lazyFn_x.fn_gradient()
-        fn_dvydx, fn_dvydy, fn_dvydz = lazyFn_y.fn_gradient()
-        fn_dvzdx, fn_dvzdy, fn_dvzdz = lazyFn_z.fn_gradient()
+        fn_dvxdx, fn_dvxdy, fn_dvxdz = lazyFn_x.fn_gradient
+        fn_dvydx, fn_dvydy, fn_dvydz = lazyFn_y.fn_gradient
+        fn_dvzdx, fn_dvzdy, fn_dvzdz = lazyFn_z.fn_gradient
         fn_curl = (fn_dvzdy-fn_dvydz) + (fn_dvxdz-fn_dvzdx) + (fn_dvydx-fn_dvxdy)
         newLazyFn.evaluate = lambda *args, **kwargs : fn_curl.evaluate(*args, **kwargs)
         desc = "(diff({},dy) - diff({},dz)) + (diff({},dz) - diff({},dx)) + (diff({},dx) - diff({},dy))"

--- a/quagmire/surfmesh/surfmesh.py
+++ b/quagmire/surfmesh/surfmesh.py
@@ -34,7 +34,7 @@ class SurfMesh(_TopoMesh):
 
     def __init__(self, *args, **kwargs):
         super(SurfMesh,self).__init__(*args, **kwargs)
-
+        self.mesh_type = 'SurfaceProcessMesh'
         # self.kappa = 1.0 # dummy value
 
         # new context manager ...

--- a/quagmire/tools/__init__.py
+++ b/quagmire/tools/__init__.py
@@ -20,3 +20,4 @@ Tools for creating and saving meshes
 
 from .meshtools import *
 from .generate_xdmf import generateXdmf as generate_xdmf
+from .io import *

--- a/quagmire/tools/io.py
+++ b/quagmire/tools/io.py
@@ -125,8 +125,7 @@ def load_saved_MeshVariables(mesh, filename, ignore_loaded_fields=True):
     Notes
     -----
     Imports all fields within the 'fields' group on the HDF5 file
-    and imports all fields contained within - except for fields
-    that are automatically loaded onto `mesh`. 
+    except fields that are already on the mesh e.g. topography, radius.
     """
 
     import h5py

--- a/quagmire/tools/io.py
+++ b/quagmire/tools/io.py
@@ -54,12 +54,16 @@ def load_quagmire_project(filename):
 
     mesh = BaseMeshClass(DM, verbose=verbose)
     mesh.__id = mesh_id
-    if not radius:
-        radius = mesh.add_variable("radius")
-        radius.load(filename)
-    mesh.radius = radius
+    if mesh.id.startswith('strimesh'):    
+        if not radius and 'radius' in field_variable_list:
+            field_variable_list.remove('radius')
+            radius_meshVariable = mesh.add_variable("radius")
+            radius_meshVariable.load(filename)
+            radius = radius_meshVariable.data
+        mesh.radius = radius
 
-    if mesh_type in ['TopoMesh', 'SurfaceProcessMesh']:
+    if mesh_type in ['TopoMesh', 'SurfaceProcessMesh'] and 'h(x,y)' in field_variable_list:
+        field_variable_list.remove('h(x,y)')
         mesh.topography.unlock()
         mesh.topography.load(filename)
         mesh.topography.lock()

--- a/quagmire/tools/io.py
+++ b/quagmire/tools/io.py
@@ -1,0 +1,98 @@
+# Copyright 2016-2020 Louis Moresi, Ben Mather, Romain Beucher
+# 
+# This file is part of Quagmire.
+# 
+# Quagmire is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or any later version.
+# 
+# Quagmire is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+# 
+# You should have received a copy of the GNU Lesser General Public License
+# along with Quagmire.  If not, see <http://www.gnu.org/licenses/>.
+
+from .meshtools import create_DMPlex_from_hdf5 as _create_DMPlex_from_hdf5
+from mpi4py import MPI as _MPI
+_comm = _MPI.COMM_WORLD
+
+def load_quagmire_project(filename):
+
+    from quagmire import FlatMesh as _FlatMesh
+    from quagmire import TopoMesh as _TopoMesh
+    from quagmire import SurfaceProcessMesh as _SurfaceProcessMesh
+    import h5py
+
+    filename = str(filename)
+
+    DM = _create_DMPlex_from_hdf5(filename)
+
+
+    known_mesh_classes = {'FlatMesh': _FlatMesh, \
+                          'TopoMesh': _TopoMesh, \
+                          'SurfaceProcessMesh' : _SurfaceProcessMesh}
+
+
+    with h5py.File(filename, mode='r', driver='mpio', comm=_comm) as h5:
+        quag = h5['quagmire']
+        verbose         = quag.attrs['verbose']
+        mesh_type       = quag.attrs['mesh_type']
+        mesh_id         = quag.attrs['id']
+        radius          = quag.attrs['radius']
+        down_neighbours = quag.attrs['downhill_neighbours']
+
+        # are there any other fields in here?
+        field_variable_list = []
+        if 'fields' in h5:
+            for field in h5['fields']:
+                field_variable_list.append(field)
+
+
+    BaseMeshClass = known_mesh_classes[mesh_type]
+
+    mesh = BaseMeshClass(DM, verbose=verbose)
+    mesh.__id = mesh_id
+    if not radius:
+        radius = mesh.add_variable("radius")
+        radius.load(filename)
+    mesh.radius = radius
+
+    if mesh_type in ['TopoMesh', 'SurfaceProcessMesh']:
+        mesh.topography.unlock()
+        mesh.topography.load(filename)
+        mesh.topography.lock()
+        # this should trigger a rebuild of downhill matrices
+        mesh.downhill_neighbours = down_neighbours
+
+
+    print("Quagmire {} is successfully rebuilt!".format(mesh_type))
+    if field_variable_list:
+        print("Additional mesh variables are available to load:")
+        for field in field_variable_list:
+            print(" - {}".format(field))
+        print("\nAdd a MeshVariable with the same name and load from this file.")
+        print("Or load a tuple of MeshVariables using load_saved_MeshVariables.")
+
+    return mesh
+
+
+def load_saved_MeshVariables(mesh, filename):
+
+    import h5py
+
+    with h5py.File(filename, mode='r', driver='mpio', comm=_comm) as h5:
+        if 'fields' in h5:
+            field_variable_list = []
+            for field in h5['fields']:
+                field_variable_list.append(field)
+
+
+    MeshVariable_list = []
+    for field in field_variable_list:
+        mvar = mesh.add_variable(field)
+        mvar.load(filename)
+        MeshVariable_list.append(mvar)
+
+    return MeshVariable_list

--- a/quagmire/topomesh/topomesh.py
+++ b/quagmire/topomesh/topomesh.py
@@ -32,7 +32,7 @@ from quagmire.function import LazyEvaluation as _LazyEvaluation
 
 class TopoMesh(object):
     def __init__(self, downhill_neighbours=2, *args, **kwargs):
-
+        self.mesh_type = 'TopoMesh'
 
         # Initialise cumulative flow vectors
         self._DX0 = self.gvec.duplicate()
@@ -717,22 +717,3 @@ class TopoMesh(object):
             else:
                 self.node_chain_list[0].append(this_chain[0])
                 self.node_chain_lookup[this_chain[0]] = 0
-
-
-    def save_quagmire_project(self, file):
-
-        import h5py
-
-        file = str(file)
-        if not file.endswith('.h5'):
-            file += '.h5'
-
-        # do all the stuff from the FlatMesh class
-        super(TopoMesh, self).save_quagmire_project(file)
-
-        # in addition to this extra stuff
-        mesh.topography.save(file)
-
-        with h5py.File(file, mode='r+', driver='mpio', comm=comm) as h5:
-            quag = h5['quagmire']
-            quag.attrs['downhill_neighbours'] = self.downhill_neighbours

--- a/quagmire/topomesh/topomesh.py
+++ b/quagmire/topomesh/topomesh.py
@@ -717,3 +717,22 @@ class TopoMesh(object):
             else:
                 self.node_chain_list[0].append(this_chain[0])
                 self.node_chain_lookup[this_chain[0]] = 0
+
+
+    def save_quagmire_project(self, file):
+
+        import h5py
+
+        file = str(file)
+        if not file.endswith('.h5'):
+            file += '.h5'
+
+        # do all the stuff from the FlatMesh class
+        super(TopoMesh, self).save_quagmire_project(file)
+
+        # in addition to this extra stuff
+        mesh.topography.save(file)
+
+        with h5py.File(file, mode='r+', driver='mpio', comm=comm) as h5:
+            quag = h5['quagmire']
+            quag.attrs['downhill_neighbours'] = self.downhill_neighbours

--- a/tests/test_2_mesh_variables.py
+++ b/tests/test_2_mesh_variables.py
@@ -87,7 +87,7 @@ def test_mesh_variable_derivative():
     phi.data = np.sin(mesh.coords[:,0])
     psi.data = np.cos(mesh.coords[:,0])
 
-    assert(np.isclose(phi.fn_gradient(0).evaluate(0.0,0.0), psi.evaluate(0.0,0.0), rtol=1.0e-3))
+    assert(np.isclose(phi.fn_gradient[0].evaluate(0.0,0.0), psi.evaluate(0.0,0.0), rtol=1.0e-3))
 
 
     return


### PR DESCRIPTION
Save quagmire projects to an HDF5 file and load them back in again. A Quagmire project `.h5` file contains:

- The mesh information (PETSc DM)
- radius (for spherical meshes)
- topography
- number of downhill neighbours

Parameters like the number of downhill neighbours are saved as HDF5 attributes nested under the "quagmire" group so it doesn't interfere with PETSc data structures.

Projects can be reloaded using the `tools.io.load_quagmire_project` function which loads all mesh variables and rebuilds data structures.
