### PR TITLE
Natural neighbours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,5 @@ __pycache__
 
 src/_fortranmodule.c
 src/_fortran-f2pywrappers.f
+
+dist/*.egg

--- a/quagmire/__init__.py
+++ b/quagmire/__init__.py
@@ -223,7 +223,7 @@ def _get_label(DM):
 
 def QuagMesh(DM, downhill_neighbours=2, verbose=True, *args, **kwargs):
     """
-    Instantiates a mesh with a height and rainfall field.
+    Instantiates a mesh in the form required for quagmire computation.
     QuagMesh identifies the type of DM and builds the necessary
     data structures for landscape processing and analysis.
 
@@ -255,6 +255,8 @@ def QuagMesh(DM, downhill_neighbours=2, verbose=True, *args, **kwargs):
     if BaseMeshType in known_basemesh_classes:
         class QuagMeshClass(known_basemesh_classes[BaseMeshType], _TopoMeshClass):
             def __init__(self, dm, *args, **kwargs):
+                if verbose:
+                    print("Underlying Mesh type: {}".format(BaseMeshType))
                 known_basemesh_classes[BaseMeshType].__init__(self, dm, verbose, *args, **kwargs)
                 _TopoMeshClass.__init__(self, downhill_neighbours, *args, **kwargs)
                 # super(QuagMeshClass, self).__init__(dm, *args, **kwargs)

--- a/quagmire/mesh/strimesh.py
+++ b/quagmire/mesh/strimesh.py
@@ -543,12 +543,12 @@ class sTriMesh(_CommonMesh):
         sms  = np.zeros_like(deshuffled)
         sms[np.indices((deshuffled.shape[0],)),:] = deshuffled[smsi,:]
 
-        nodes, natural_neighbours_count = np.unique(sms[:,0], return_counts=True)
+        natural_neighbours_count = np.bincount(sms[:,0])
         iend = np.cumsum(natural_neighbours_count)
         istart = np.zeros_like(iend)
         istart[1:] = iend[:-1]
 
-        natural_neighbours = -1 * np.ones((self.npoints, natural_neighbours_count.max()+1), dtype=np.int)
+        natural_neighbours = np.full((self.npoints, natural_neighbours_count.max()+1), -1, dtype=np.int)
 
         for j in range(0,self.npoints):
             natural_neighbours[j, 0] = j

--- a/quagmire/mesh/strimesh.py
+++ b/quagmire/mesh/strimesh.py
@@ -232,23 +232,6 @@ class sTriMesh(_CommonMesh):
         self.pointwise_area.lock()
 
 
-    def get_local_mesh(self):
-        """
-        Retrieves the local mesh information
-
-        Returns
-        -------
-        x : array of floats, shape (n,)
-            x coordinates
-        y : array of floats, shape (n,)
-            y coordinates
-        simplices : array of ints, shape (ntri, 3)
-            simplices of the triangulation
-        bmask  : array of bools, shape (n,2)
-        """
-        return self.tri.lons, self.tri.lats, self.tri.simplices, self.bmask
-
-
     def calculate_area_weights(self):
         """
         Calculate pointwise weights and area
@@ -298,8 +281,7 @@ class sTriMesh(_CommonMesh):
             list of neighbours that are connected by line segments
             to the specified `point`
         """
-
-        return self.vertex_neighbour_vertices[1][self.vertex_neighbour_vertices[0][point]:self.vertex_neighbour_vertices[0][point+1]]
+        return self.natural_neighbours[point,1:self.natural_neighbours_count[point]]
 
 
     def derivative_grad(self, PHI, nit=10, tol=1e-8):
@@ -354,144 +336,6 @@ class sTriMesh(_CommonMesh):
 
         return u_xx + u_yy + u_zz
 
-
-    def get_edge_lengths(self):
-        """
-        Find all edges in a triangluation and their lengths
-
-        Returns
-        -------
-        edges : array of ints, shape (l,2)
-            segments that make up the triangulation
-        edge_lengths : array of floats, shape (l,)
-            length of each segment.
-        """
-        points = self.tri.points
-
-        i1 = np.sort([self.tri.simplices[:,0], self.tri.simplices[:,1]], axis=0)
-        i2 = np.sort([self.tri.simplices[:,0], self.tri.simplices[:,2]], axis=0)
-        i3 = np.sort([self.tri.simplices[:,1], self.tri.simplices[:,2]], axis=0)
-
-        a = np.hstack([i1, i2, i3]).T
-
-        # find unique rows in numpy array
-        # <http://stackoverflow.com/questions/16970982/find-unique-rows-in-numpy-array>
-        b = np.ascontiguousarray(a).view(np.dtype((np.void, a.dtype.itemsize * a.shape[1])))
-        edges = np.unique(b).view(a.dtype).reshape(-1, a.shape[1])
-
-        edge_lengths = np.linalg.norm(points[edges[:,0]] - points[edges[:,1]], axis=1)
-
-        self.edges = edges
-        self.edge_lengths = edge_lengths
-
-
-    def construct_neighbours(self):
-        """
-        Find neighbours from edges and store as CSR coordinates.
-
-        This allows you to directly ask the neighbours for a given node a la Qhull,
-        or efficiently construct a sparse matrix (PETSc/SciPy)
-
-        Notes
-        -----
-        This method searches only for immediate note neighbours that are connected
-        by a line segment. For extended neighbour searches, refer to
-        `construct_extended_neighbour_cloud` or `construct_neighbour_cloud`.
-        """
-
-        row = np.hstack([self.edges[:,0], self.edges[:,1]])
-        col = np.hstack([self.edges[:,1], self.edges[:,0]])
-        val = np.hstack([self.edge_lengths, self.edge_lengths])
-
-        # sort by row
-        sort = row.argsort()
-        row = row[sort].astype(PETSc.IntType)
-        col = col[sort].astype(PETSc.IntType)
-        val = val[sort]
-
-        nnz = np.bincount(row) # number of nonzeros
-        indptr = np.insert(np.cumsum(nnz),0,0)
-
-        self.vertex_neighbours = nnz.astype(PETSc.IntType)
-        self.vertex_neighbour_vertices = indptr, col
-        self.vertex_neighbour_distance = val
-
-        # We may not need this, but constuct anyway for now!
-        neighbours = [[]]*self.npoints
-        closed_neighbours = [[]]*self.npoints
-
-        for i in range(indptr.size-1):
-            start, end = indptr[i], indptr[i+1]
-            neighbours[i] = np.array(col[start:end])
-            closed_neighbours[i] = np.hstack([i, neighbours[i]])
-
-        self.neighbour_list = np.array(neighbours)
-        self.neighbour_array = np.array(closed_neighbours)
-
-
-    def construct_extended_neighbour_cloud(self):
-        """
-        Find extended node neighbours.
-
-        This searches for immediate neighbours (nodes that are joined
-        by a line segment) and extended neighbours (neighbours of nodes
-        joined by a line segment)
-
-        Notes
-        -----
-        This method is (currently) inefficient and has been deprecated
-        in favour of `construct_neighbour_cloud`, which uses a k-d tree
-        to search for nearsest neighbours based on distance.
-        """
-        from quagmire._fortran import ncloud
-
-        # nnz_max = np.bincount(self.tri.simplices.ravel()).max()
-
-        unique, neighbours = np.unique(self.tri.simplices.ravel(), return_counts=True)
-        self.near_neighbours = neighbours
-
-
-        nnz_max = self.near_neighbours.max()
-
-        cloud = ncloud(self.tri.simplices.T + 1, self.npoints, nnz_max)
-        cloud -= 1 # convert to C numbering
-        cloud_mask = cloud==-1
-        cloud_masked = np.ma.array(cloud, mask=cloud_mask)
-
-        self.extended_neighbours = np.count_nonzero(~cloud_mask, axis=1)
-        self.extended_neighbours_mask = cloud_mask
-
-        dx = self.tri.points[cloud_masked,0] - self.tri.points[:,0].reshape(-1,1)
-        dy = self.tri.points[cloud_masked,1] - self.tri.points[:,1].reshape(-1,1)
-        dist = np.hypot(dx,dy)
-        dist[cloud_mask] = 1.0e50
-
-        ii =  np.argsort( dist, axis=1)
-
-        t = perf_counter()
-
-        ## Surely there is some np.argsort trick here to avoid the for loop ???
-
-        neighbour_cloud = np.ones_like(cloud, dtype=np.int )
-        neighbour_cloud_distances = np.empty_like(dist)
-
-        for node in range(0, self.npoints):
-            neighbour_cloud[node, :] = cloud[node, ii[node,:]]
-            neighbour_cloud_distances[node, :] = dist[node, ii[node,:]]
-
-        # The same mask should be applicable to the sorted array
-
-        self.neighbour_cloud = np.ma.array( neighbour_cloud, mask = cloud_mask)
-        self.neighbour_cloud_distances = np.ma.array( neighbour_cloud_distances, mask = cloud_mask)
-
-        # Create a mask that can pick the natural neighbours only
-
-        ind = np.indices(self.neighbour_cloud.shape)[1]
-        mask = ind > self.near_neighbours.reshape(-1,1)
-        self.near_neighbours_mask = mask
-
-
-        print(" - Array sort {}s".format(perf_counter()-t))
 
     def construct_natural_neighbour_cloud(self):
         """
@@ -581,52 +425,12 @@ class sTriMesh(_CommonMesh):
         `size` is set to.
         """
         nndist, nncloud = self.cKDTree.query(self.tri.points, k=size)
-
         self.neighbour_cloud = nncloud
         self.neighbour_cloud_distances = nndist
 
         neighbours = np.bincount(self.tri.simplices.ravel(), minlength=self.npoints)
         self.near_neighbours = neighbours + 2
         self.extended_neighbours = np.full_like(neighbours, size)
-
-        self.near_neighbour_mask = np.zeros_like(self.neighbour_cloud, dtype=np.bool)
-
-        for node in range(0,self.npoints):
-            self.near_neighbour_mask[node, 0:self.near_neighbours[node]] = True
-
-        return
-
-
-    def _build_smoothing_matrix(self):
-
-        indptr, indices = self.vertex_neighbour_vertices
-        weight  = 1.0/self.weight
-        nweight = weight[indices]
-
-        lgmask = self.lgmap_row.indices >= 0
-
-
-        nnz = self.vertex_neighbours[lgmask] + 1
-
-        # smoothMat = self.dm.createMatrix()
-        # smoothMat.setOption(smoothMat.Option.NEW_NONZERO_LOCATIONS, False)
-        smoothMat = PETSc.Mat().create(comm=comm)
-        smoothMat.setType('aij')
-        smoothMat.setSizes(self.sizes)
-        smoothMat.setLGMap(self.lgmap_row, self.lgmap_col)
-        smoothMat.setFromOptions()
-        smoothMat.setPreallocationNNZ(nnz)
-
-        # read in data
-        smoothMat.setValuesLocalCSR(indptr.astype(PETSc.IntType), indices.astype(PETSc.IntType), nweight)
-        self.lvec.setArray(weight)
-        self.dm.localToGlobal(self.lvec, self.gvec)
-        smoothMat.setDiagonal(self.gvec)
-
-        smoothMat.assemblyBegin()
-        smoothMat.assemblyEnd()
-
-        self.localSmoothMat = smoothMat
 
 
     def local_area_smoothing(self, data, its=1, centre_weight=0.75):
@@ -656,45 +460,8 @@ class sTriMesh(_CommonMesh):
             smooth_data_old[:] = smooth_data
             smooth_data = centre_weight*smooth_data_old + \
                           (1.0 - centre_weight)*self.rbf_smoother(smooth_data)
-            smooth_data[:] = self.sync(smooth_data)
 
         return smooth_data
-
-
-    def local_area_smoothing_old(self, data, its=1, centre_weight=0.75):
-        """
-        Local area smoothing using a smoothing matrix
-        (DEPRECATED! Use `local_area_smoothing` instead!)
-
-        Parameters
-        ----------
-        data : array of floats, shape (n,)
-            field variable to be smoothed
-        its : int
-            number of iterations (default: 1)
-        centre_weight : float
-            weight to apply to centre nodes (default: 0.75)
-            other nodes are weighted by (1 - `centre_weight`)
-
-        Returns
-        -------
-        sm : array of floats, shape (n,)
-            smoothed field variable
-        """
-        import warnings
-        warnings.warn("deprecated", DeprecationWarning)
-
-        self.lvec.setArray(data)
-        self.dm.localToGlobal(self.lvec, self.gvec)
-        smooth_data = self.gvec.copy()
-
-        for i in range(0, its):
-            self.localSmoothMat.mult(smooth_data, self.gvec)
-            smooth_data = centre_weight*smooth_data + (1.0 - centre_weight)*self.gvec
-
-        self.dm.globalToLocal(smooth_data, self.lvec)
-
-        return self.lvec.array
 
 
     def _construct_rbf_weights(self, delta=None):
@@ -757,16 +524,18 @@ class sTriMesh(_CommonMesh):
 
     def build_rbf_smoother(self, delta, iterations=1):
 
-        trimesh_self = self
+        strimesh_self = self
 
         class _rbf_smoother_object(object):
 
             def __init__(inner_self, delta, iterations=1):
 
                 if delta == None:
-                    delta = trimesh_self.neighbour_cloud_distances[:, 1].mean()  ## NOT IDEAL IN PARALLEL !!!
+                    strimesh_self.lvec.setArray(strimesh_self.neighbour_cloud_distances[:, 1])
+                    strimesh_self.dm.localToGlobal(strimesh_self.lvec, strimesh_self.gvec)
+                    delta = strimesh_self.gvec.sum() / strimesh_self.gvec.getSize()
 
-                inner_self._mesh = trimesh_self
+                inner_self._mesh = strimesh_self
                 inner_self.delta = delta
                 inner_self.iterations = iterations
                 inner_self.gaussian_dist_w = inner_self._mesh._rbf_weights(delta)
@@ -792,12 +561,13 @@ class sTriMesh(_CommonMesh):
                         iterations = inner_self.iterations
 
                 def smoother_fn(*args, **kwargs):
+                    import quagmire
 
                     smooth_node_values = inner_self._apply_rbf_on_my_mesh(lazyFn, iterations=iterations)
 
                     if len(args) == 1 and args[0] == lazyFn._mesh:
                         return smooth_node_values
-                    elif len(args) == 1 and isinstance(args[0], (quagmire.mesh.trimesh.TriMesh, quagmire.mesh.pixmesh.PixMesh) ):
+                    elif len(args) == 1 and quagmire.mesh.check_object_is_a_q_mesh(args[0]):
                         mesh = args[0]
                         return inner_self._mesh.interpolate(lazyFn._mesh.coords[:,0], lazyFn._mesh.coords[:,1], zdata=smooth_node_values, **kwargs)
                     else:

--- a/quagmire/mesh/trimesh.py
+++ b/quagmire/mesh/trimesh.py
@@ -435,12 +435,12 @@ class TriMesh(_CommonMesh):
         sms  = np.zeros_like(deshuffled)
         sms[np.indices((deshuffled.shape[0],)),:] = deshuffled[smsi,:]
 
-        nodes, natural_neighbours_count = np.unique(sms[:,0], return_counts=True)
+        natural_neighbours_count = np.bincount(sms[:,0])
         iend = np.cumsum(natural_neighbours_count)
         istart = np.zeros_like(iend)
         istart[1:] = iend[:-1]
 
-        natural_neighbours = -1 * np.ones((self.npoints, natural_neighbours_count.max()+1), dtype=np.int)
+        natural_neighbours = np.full((self.npoints, natural_neighbours_count.max()+1), -1, dtype=np.int)
 
         for j in range(0,self.npoints):
             natural_neighbours[j, 0] = j

--- a/quagmire/mesh/trimesh.py
+++ b/quagmire/mesh/trimesh.py
@@ -91,7 +91,7 @@ class TriMesh(_CommonMesh):
     neighbour_cloud : array of ints, shape(n,25)
         array of nearest node neighbours by distance
     near_neighbour_mask : array of bools, shape(n,25)
-        mask immediate node neighbours in `neighbour_cloud`
+        mask immediate node neighbours in `neighbour_cloud`  (They may not be there !! )
     timings : dict
         Timing information for each Quagmire routine
     """
@@ -394,6 +394,7 @@ class TriMesh(_CommonMesh):
         in favour of `construct_neighbour_cloud`, which uses a k-d tree
         to search for nearsest neighbours based on distance.
         """
+
         import warnings
         warnings.warn("deprecated", DeprecationWarning)
 
@@ -466,12 +467,14 @@ class TriMesh(_CommonMesh):
         `size` is set to.
         """
         nndist, nncloud = self.cKDTree.query(self.tri.points, k=size)
+        self.neighbour_cloud = nncloud
+        self.neighbour_cloud_distances = nndist
 
         neighbours = np.bincount(self.tri.simplices.ravel(), minlength=self.npoints)
         self.near_neighbours = neighbours + 2
         self.extended_neighbours = np.full_like(neighbours, size)
 
-        self.near_neighbour_mask = np.zeros_like(self.neighbour_cloud, dtype=np.bool)
+        self.near_neighbour_mask = np.zeros_like(nncloud, dtype=np.bool)
 
         for node in range(0,self.npoints):
             self.near_neighbour_mask[node, 0:self.near_neighbours[node]] = True
@@ -492,8 +495,6 @@ class TriMesh(_CommonMesh):
 
             ## Nothing is done about the nndist array, yet...
 
-        self.neighbour_cloud = nncloud
-        self.neighbour_cloud_distances = nndist
 
         return
 

--- a/quagmire/topomesh/topomesh.py
+++ b/quagmire/topomesh/topomesh.py
@@ -211,58 +211,34 @@ class TopoMesh(object):
     def _build_down_neighbour_arrays(self, nearest=True):
 
         nodes = list(range(0,self.npoints))
-        # nheight  = self.height[self.neighbour_cloud]
-        nheight  = self._heightVariable.data[self.neighbour_cloud]
+        nheight  = self._heightVariable.data[self.natural_neighbours]
+        nheight[np.where(self.natural_neighbours == -1)] = np.finfo(nheight.dtype).max
 
         nheightidx = np.argsort(nheight, axis=1)
-
-        nheightn = nheight.copy()
-        # nheightn[~self.near_neighbour_mask] += self.height.max()
-        nheightn[~self.near_neighbour_mask] += self._heightVariable.data.max()
-        nheightnidx = np.argsort(nheightn, axis=1)
 
         ## How many low neighbours are there in each ?
 
         idxrange  = np.where(nheightidx==0)[1]
-        idxnrange = np.where(nheightnidx==0)[1]
 
         ## First the STD, 1-neighbour
 
         idx  = nheightidx[:,0]
-        idxn = nheightnidx[:,0]
-
-        # Pick either extended or standard ...
-        use_extended = np.where(idxnrange == 0)
-
-        index1 = self.neighbour_cloud[nodes, idxn[nodes]]
-
-        if not nearest:
-            index1[use_extended] = self.neighbour_cloud[use_extended, idx[use_extended]]
+        index1 = self.natural_neighbours[nodes, idx[nodes]]
 
         # store in neighbour dictionary
         self.down_neighbour = dict()
         self.down_neighbour[1] = index1.astype(PETSc.IntType)
 
-
-        ## Now all higher neighours
+        ## Now all next-lower-level neighours
 
         for i in range(1, self.downhill_neighbours):
             n = i + 1
 
             idx  = nheightidx[:,i]
-            idxn = nheightnidx[:,i]
+            indexN = self.natural_neighbours[nodes, idx[nodes]]
 
-            indexN = self.neighbour_cloud[nodes, idxn[nodes]]
-
-            if not nearest:
-                use_extended = np.where(idxnrange < n)
-                indexN[use_extended] = self.neighbour_cloud[use_extended, idx[use_extended]]
-
-                failed = np.where(idxrange < n)
-                indexN[failed] = index1[failed]
-            else:
-                failed = np.where(idxnrange < n)
-                indexN[failed] = index1[failed]
+            failed = np.where(idxrange < n)
+            indexN[failed] = index1[failed]
 
             # store in neighbour dictionary
             self.down_neighbour[n] = indexN.astype(PETSc.IntType)
@@ -270,7 +246,7 @@ class TopoMesh(object):
 
     def _build_adjacency_matrix_iterate(self):
 
-        self._build_down_neighbour_arrays(nearest=False)
+        self._build_down_neighbour_arrays(nearest=True)
 
         self.adjacency = dict()
         self.uphill = dict()
@@ -751,7 +727,7 @@ class TopoMesh(object):
 
 ### Methods copied over from obseleted SurfMesh class
 
-    def low_points_local_flood_fill(self, its=99999, scale=1.0, smoothing_steps=2):
+    def low_points_local_flood_fill(self, its=99999, scale=1.0, smoothing_steps=2, ref_height=0.0):
         """
         Fill low points with a local flooding algorithm.
           - its is the number of uphill propagation steps
@@ -762,12 +738,12 @@ class TopoMesh(object):
         if self.rank==0 and self.verbose:
             print("Low point local flood fill")
 
-        my_low_points = self.identify_low_points()
+        my_low_points = self.identify_low_points(ref_height=ref_height)
 
         self.topography.unlock()
         h = self.topography.data
 
-        fill_height =  (h[self.neighbour_cloud[my_low_points,1:7]].mean(axis=1)-h[my_low_points])
+        fill_height =  (h[self.natural_neighbours[my_low_points]] * self.natural_neighbours_mask[my_low_points]).mean(axis=1) - h[my_low_points]
 
         new_h = self.uphill_propagation(my_low_points,  fill_height, scale=scale,  its=its, fill=0.0)
         new_h = self.sync(new_h)
@@ -785,7 +761,7 @@ class TopoMesh(object):
 
         return
 
-    def low_points_local_patch_fill(self, its=1, smoothing_steps=1):
+    def low_points_local_patch_fill(self, its=1, smoothing_steps=1, ref_height=0.0):
 
         from petsc4py import PETSc
         t = perf_counter()
@@ -793,9 +769,8 @@ class TopoMesh(object):
             print("Low point local patch fill")
 
         for iteration in range(0,its):
-            low_points = self.identify_low_points()
+            low_points = self.identify_low_points(ref_height=ref_height)
 
-            self.topography.unlock()
 
             h = self.topography.data
             delta_height = np.zeros_like(h)
@@ -803,12 +778,13 @@ class TopoMesh(object):
             ## Note, the smoother has a communication barrier so needs to be called even if it has no work to do on this process
 
             if len(low_points) != 0:
-                delta_height[low_points] =  (h[self.neighbour_cloud[low_points,1:5]].mean(axis=1) -
+                delta_height[low_points] =  ((h[self.natural_neighbours[low_points]] * self.natural_neighbours_mask[low_points]).mean(axis=1) -
                                                          h[low_points])
             ## Note, the smoother has a communication barrier so needs to be called even
             ## if len(low_points==0) and there is no work to do on this process
             smoothed_height = h + self.rbf_smoother(delta_height, iterations=smoothing_steps)
 
+            self.topography.unlock()
             self.topography.data = np.maximum(smoothed_height, h)
             self.topography.sync()
             self.topography.lock()
@@ -823,7 +799,7 @@ class TopoMesh(object):
         return
 
 
-    def low_points_swamp_fill(self, its=1000, saddles=True, ref_height=0.0, ref_gradient=0.001):
+    def low_points_swamp_fill(self, its=1000, saddles=None, ref_height=0.0, ref_gradient=0.001):
 
         import petsc4py
         from petsc4py import PETSc
@@ -844,28 +820,38 @@ class TopoMesh(object):
         t = perf_counter()
         ctmt = self.uphill_propagation(my_low_points,  my_glow_points, its=its, fill=-999999).astype(np.int)
 
+        height = self.topography.data.copy()
+
         if self.rank==0 and self.verbose:
             print("Build low point catchments - ", perf_counter() - t, " seconds")
 
-        if saddles:  # Find saddle points on the catchment edge - catchment detection is via down-neighbour 1,
-                     # so neighbour 2 (or 3) is the earliest detection opportunity for a spill
+        # if saddles:  
+        #     # Find saddle points on the catchment edge - catchment detection is via down-neighbour 1,
+        #     # so neighbour 2 (or 3) is the earliest detection opportunity for a spill
 
-            cedges = np.where(ctmt[self.down_neighbour[2]] != ctmt )[0] ## local numbering
-            try:
-                cedges3 = np.where(ctmt[self.down_neighbour[3]] != ctmt )[0] ## local numbering
-                cedges = np.unique(np.hstack((cedges,cedges3)))
-            except:
-                pass
+        #     cedges = np.where(ctmt[self.down_neighbour[2]] != ctmt )[0] ## local numbering
+        #     try:
+        #         cedges3 = np.where(ctmt[self.down_neighbour[3]] != ctmt )[0] ## local numbering
+        #         cedges = np.unique(np.hstack((cedges,cedges3)))
+        #     except:
+        #         pass
 
-        else:        # Find all edge points (this does not seem to work in most cases ... why not ?)
-            ctmt2 = ctmt[self.neighbour_cloud] - ctmt.reshape(-1,1)
-            ctmt3 = ctmt2 * self.near_neighbour_mask
-            cedges = np.where(ctmt3.any(axis=1))[0]
+        # else:    
+        #     
+
+# Possible problem - low point that should flow out the side of the domain boundary. 
+
+        # Find all catchment-edge points (mix of catchments in the natural neighbours)
+        ctmt2 = (ctmt[self.natural_neighbours] - ctmt.reshape(-1,1)) * (self.natural_neighbours_mask)
+
+        # filter out points that whose other-catchment neighbours are not lower
+        dh = (height[self.natural_neighbours] - height.reshape(-1,1)) * (self.natural_neighbours_mask)
+
+        ctmt3 = ctmt2 * (dh < 0.0)
+        cedges = np.where(ctmt3.any(axis=1))[0]
 
         outer_edges = np.where(~self.bmask)[0]
         edges = np.unique(np.hstack((cedges,outer_edges)))
-
-        height = self.topography.data.copy()
 
         ## In parallel this is all the low points where this process may have a spill-point
         my_catchments = np.unique(ctmt)
@@ -920,7 +906,7 @@ class TopoMesh(object):
 
         global_spill_points = comm.bcast(all_spill_points, root=0)
 
-        height2 = np.zeros_like(height) + ref_height
+        height2 = np.zeros_like(height) 
 
         for i, spill in enumerate(global_spill_points):
             this_catchment = int(spill['c'])

--- a/quagmire/topomesh/topomesh.py
+++ b/quagmire/topomesh/topomesh.py
@@ -776,9 +776,11 @@ class TopoMesh(object):
 
             ## Note, the smoother has a communication barrier so needs to be called even if it has no work to do on this process
 
-            if len(low_points) != 0:
-                delta_height[low_points] =  ((h[self.natural_neighbours[low_points]] * self.natural_neighbours_mask[low_points]).max(axis=1) -
-                                                         h[low_points])
+            for i in low_points:
+                delta_height[i] =  ( 0.75 * (h[self.natural_neighbours[i,1:self.natural_neighbours_count[i]]]).min() +
+                                     0.25 * (h[self.natural_neighbours[i,1:self.natural_neighbours_count[i]]]).max() 
+                                              - h[i] )
+
             ## Note, the smoother has a communication barrier so needs to be called even
             ## if len(low_points==0) and there is no work to do on this process
             smoothed_height = h + self.rbf_smoother(delta_height, iterations=smoothing_steps)

--- a/quagmire/topomesh/topomesh.py
+++ b/quagmire/topomesh/topomesh.py
@@ -771,14 +771,13 @@ class TopoMesh(object):
         for iteration in range(0,its):
             low_points = self.identify_low_points(ref_height=ref_height)
 
-
             h = self.topography.data
             delta_height = np.zeros_like(h)
 
             ## Note, the smoother has a communication barrier so needs to be called even if it has no work to do on this process
 
             if len(low_points) != 0:
-                delta_height[low_points] =  ((h[self.natural_neighbours[low_points]] * self.natural_neighbours_mask[low_points]).mean(axis=1) -
+                delta_height[low_points] =  ((h[self.natural_neighbours[low_points]] * self.natural_neighbours_mask[low_points]).max(axis=1) -
                                                          h[low_points])
             ## Note, the smoother has a communication barrier so needs to be called even
             ## if len(low_points==0) and there is no work to do on this process


### PR DESCRIPTION
These are the changes to split out the functionality for natural neighbour searches on the mesh from the near-neighbour searches that are used for smoothing and navigation to nearby points. 

The former uses the stripy / stripack routines and the latter is based on k-d trees. 

