### PR TITLE
Clean the functions, remove the mesh dependency etc.

### DIFF
--- a/quagmire/function/__init__.py
+++ b/quagmire/function/__init__.py
@@ -1,4 +1,4 @@
-from .function_classes import LazyEvaluation, LazyGradientEvaluation, parameter
+from .function_classes import LazyEvaluation, parameter
 from . import math
 from . import misc
 from . import stats

--- a/quagmire/function/function_classes.py
+++ b/quagmire/function/function_classes.py
@@ -31,16 +31,9 @@ class LazyEvaluation(object):
     def id(self):
         return self.__id
 
-
-    def __init__(self, mesh=None):
-        """Lazy evaluation of mesh variables / parameters
-           If no mesh is provided then no gradient function can be implemented"""
-
+    def __init__(self):
         self.__id = "q_fn_{}".format(self._count())
-
         self.description = ""
-        self._mesh = mesh
-        self.mesh_data = False
         self.dependency_list = set([self.id])
 
         return
@@ -78,59 +71,6 @@ class LazyEvaluation(object):
     def evaluate(self, *args, **kwargs):
         raise(NotImplementedError)
 
-
-    @property
-    def fn_gradient(self):
-        mesh = self._mesh
-        newLazyGradient = LazyGradientEvaluation(mesh=mesh)
-        newLazyGradient.evaluate = self._fn_gradient
-        newLazyGradient.description = "d({0})/dX,d({0})/dY".format(self.description)
-        newLazyGradient.dependency_list = self.dependency_list
-        return newLazyGradient
-    
-
-    def _fn_gradient(self, *args, **kwargs):
-
-        import quagmire
-
-        if self._mesh is None and mesh is None:
-            raise RuntimeError("fn_gradient is a numerical differentiation routine based on derivatives of a fitted spline function on a mesh. The function {} has no associated mesh. To obtain *numerical* derivatives of this function, you can provide a mesh to the gradient function. The usual reason for this error is that your function is not based upon mesh variables and can, perhaps, be differentiated without resort to interpolating splines. ".format(self.__repr__()))
-
-
-        elif self._mesh is not None:
-            diff_mesh = self._mesh
-        else:
-            quagmire.mesh.check_object_is_a_q_mesh_and_raise(mesh)
-            diff_mesh = mesh
-
-        local_array = self.evaluate(diff_mesh)
-
-        df_tuple = diff_mesh.derivative_grad(local_array, nit=10, tol=1e-8)
-        ndim = len(df_tuple)
-
-        if len(args) == 1 and args[0] == diff_mesh:
-            return df_tuple
-        elif len(args) == 1 and quagmire.mesh.check_object_is_a_q_mesh_and_raise(args[0]):
-            mesh = args[0]
-            df_interp = []
-            for df in df_tuple:
-                result = diff_mesh.interpolate(mesh.coords[:,0], mesh.coords[:,1], zdata=df, **kwargs)
-                df_interp.append(result)
-            return df_interp
-        elif len(args) > 1:
-            xi = np.atleast_1d(args[0])  # .resize(-1,1)
-            yi = np.atleast_1d(args[1])  # .resize(-1,1)
-            df_interp = []
-            for df in df_tuple:
-                i, e = diff_mesh.interpolate(xi, yi, zdata=df, **kwargs)
-                df_interp.append(i)
-            return df_interp
-        else:
-            err_msg = "Invalid number of arguments\n"
-            err_msg += "Input a valid mesh or coordinates in x,y directions"
-            raise ValueError(err_msg)
-
-
     @property
     def description(self):
         return self._description
@@ -143,10 +83,7 @@ class LazyEvaluation(object):
 
     def __mul__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) * other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})*({})".format(self.description, other.description)
         newLazyFn.dependency_list |= self.dependency_list | other.dependency_list
@@ -154,10 +91,7 @@ class LazyEvaluation(object):
     
     def __rmul__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) * other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})*({})".format(other.description, self.description)
         newLazyFn.dependency_list |= other.dependency_list | self.dependency_list
@@ -165,10 +99,7 @@ class LazyEvaluation(object):
 
     def __add__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) + other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})+({})".format(self.description, other.description)
         newLazyFn.dependency_list |= self.dependency_list | other.dependency_list
@@ -176,10 +107,7 @@ class LazyEvaluation(object):
     
     def __radd__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) + other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})+({})".format(other.description, self.description)
         newLazyFn.dependency_list |= other.dependency_list | self.dependency_list
@@ -187,10 +115,7 @@ class LazyEvaluation(object):
 
     def __truediv__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) / other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})/({})".format(self.description, other.description)
         newLazyFn.dependency_list |= self.dependency_list | other.dependency_list
@@ -199,10 +124,7 @@ class LazyEvaluation(object):
 
     def __sub__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) - other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})-({})".format(self.description, other.description)
         newLazyFn.dependency_list |= self.dependency_list | other.dependency_list
@@ -210,17 +132,14 @@ class LazyEvaluation(object):
     
     def __rsub__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) - other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})-({})".format(other.description, self.description)
         newLazyFn.dependency_list |= other.dependency_list | self.dependency_list
         return newLazyFn
 
     def __neg__(self):
-        newLazyFn = LazyEvaluation(mesh=self._mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : -1.0 * self.evaluate(*args, **kwargs)
         newLazyFn.description = "-({})".format(self.description)
         newLazyFn.dependency_list |= self.dependency_list
@@ -230,7 +149,7 @@ class LazyEvaluation(object):
     def __pow__(self, exponent):
         if isinstance(exponent, (float, int)):
             exponent = parameter(float(exponent))
-        newLazyFn = LazyEvaluation(mesh=self._mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : np.power(self.evaluate(*args, **kwargs), exponent.evaluate(*args, **kwargs))
         newLazyFn.description = "({})**({})".format(self.description, exponent.description)
         newLazyFn.dependency_list |= self.dependency_list | exponent.dependency_list
@@ -238,10 +157,7 @@ class LazyEvaluation(object):
 
     def __lt__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) < other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})<({})".format(self.description, other.description)
         newLazyFn.dependency_list |= self.dependency_list | other.dependency_list
@@ -249,10 +165,7 @@ class LazyEvaluation(object):
 
     def __le__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) <= other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})<=({})".format(self.description, other.description)
         newLazyFn.dependency_list |= self.dependency_list | other.dependency_list
@@ -260,10 +173,7 @@ class LazyEvaluation(object):
 
     def __eq__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) == other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})==({})".format(self.description, other.description)
         newLazyFn.dependency_list |= self.dependency_list | other.dependency_list
@@ -271,10 +181,7 @@ class LazyEvaluation(object):
     
     def __ne__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) != other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})!=({})".format(self.description, other.description)
         newLazyFn.dependency_list |= self.dependency_list | other.dependency_list
@@ -282,10 +189,7 @@ class LazyEvaluation(object):
 
     def __ge__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) >= other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})>=({})".format(self.description, other.description)
         newLazyFn.dependency_list |= self.dependency_list | other.dependency_list
@@ -293,122 +197,12 @@ class LazyEvaluation(object):
     
     def __gt__(self, other):
         other = self.convert(other)
-        mesh = self._mesh
-        if mesh == None:
-            mesh = other._mesh
-        newLazyFn = LazyEvaluation(mesh=mesh)
+        newLazyFn = LazyEvaluation()
         newLazyFn.evaluate = lambda *args, **kwargs : self.evaluate(*args, **kwargs) > other.evaluate(*args, **kwargs)
         newLazyFn.description = "({})>({})".format(self.description, other.description)
         newLazyFn.dependency_list |= self.dependency_list | other.dependency_list
         return newLazyFn
         
-
-class LazyGradientEvaluation(LazyEvaluation):
-
-    def __init__(self, mesh=None):
-        super(LazyGradientEvaluation, self).__init__(mesh=mesh)
-
-
-    def __getitem__(self, dirn):
-        return self._fn_gradient(dirn=dirn, mesh=self._mesh)
-
-
-    @property
-    def fn_gradient(self):
-        raise NotImplementedError("gradient operations on the 'LazyGradientEvaluation' sub-class are not supported")
-
-    def _fn_gradient(self, dirn=None, mesh=None):
-        """
-        The generic mechanism for obtaining the gradient of a lazy variable is
-        to evaluate the values on the mesh at the time in question and use the mesh gradient
-        operators to compute the new values.
-
-        Sub classes may have more efficient approaches. MeshVariables have
-        stored data and don't need to evaluate values. Parameters have Gradients
-        that are identically zero ... etc
-        """
-
-        import quagmire
-
-        if self._mesh is None and mesh is None:
-            raise RuntimeError("fn_gradient is a numerical differentiation routine based on derivatives of a fitted spline function on a mesh. The function {} has no associated mesh. To obtain *numerical* derivatives of this function, you can provide a mesh to the gradient function. The usual reason for this error is that your function is not based upon mesh variables and can, perhaps, be differentiated without resort to interpolating splines. ".format(self.__repr__()))
-
-
-        elif self._mesh is not None:
-            diff_mesh = self._mesh
-        else:
-            quagmire.mesh.check_object_is_a_q_mesh_and_raise(mesh)
-            diff_mesh = mesh
-
-        def new_fn_x(*args, **kwargs):
-            dx, dy = self.evaluate(diff_mesh)
-
-            if len(args) == 1 and args[0] == diff_mesh:
-                return dx
-
-            elif len(args) == 1 and quagmire.mesh.check_object_is_a_q_mesh_and_raise(args[0]):
-                mesh = args[0]
-                return diff_mesh.interpolate(mesh.coords[:,0], mesh.coords[:,1], zdata=dx, **kwargs)
-            elif len(args) > 1:
-                xi = np.atleast_1d(args[0])
-                yi = np.atleast_1d(args[1])
-                i, e = diff_mesh.interpolate(xi, yi, zdata=dx, **kwargs)
-                return i
-            else:
-                err_msg = "Invalid number of arguments\n"
-                err_msg += "Input a valid mesh or coordinates in x,y directions"
-                raise ValueError(err_msg)
-
-        def new_fn_y(*args, **kwargs):
-            dx, dy = self.evaluate(diff_mesh)
-
-            if len(args) == 1 and args[0] == diff_mesh:
-                return dy
-            elif len(args) == 1 and quagmire.mesh.check_object_is_a_q_mesh_and_raise(args[0]):
-                mesh = args[0]
-                return diff_mesh.interpolate(mesh.coords[:,0], mesh.coords[:,1], zdata=dy, **kwargs)
-            elif len(args) > 1:
-                xi = np.atleast_1d(args[0])  # .resize(-1,1)
-                yi = np.atleast_1d(args[1])  # .resize(-1,1)
-                i, e = diff_mesh.interpolate(xi, yi, zdata=dy, **kwargs)
-                return i
-            else:
-                err_msg = "Invalid number of arguments\n"
-                err_msg += "Input a valid mesh or coordinates in x,y directions"
-                raise ValueError(err_msg)
-
-
-        d1 = len(self.description)//2
-        d2 = d1 + 1
-
-        newLazyFn_dx = LazyEvaluation(mesh=diff_mesh)
-        newLazyFn_dx.evaluate = new_fn_x
-        newLazyFn_dx.description = self.description[:d1]
-        newLazyFn_dy = LazyEvaluation(mesh=diff_mesh)
-        newLazyFn_dy.evaluate = new_fn_y
-        newLazyFn_dy.description = self.description[d2:]
-
-        if dirn == 0:
-            return newLazyFn_dx
-        elif dirn == 1:
-            return newLazyFn_dy
-        else:
-            raise ValueError("dirn can only be set to 0 or 1")
-
-
-
-## need a fn.coord to extract (x or y) ??
-
-# class variable(LazyEvaluation):
-#     """Lazy evaluation of Mesh Variables"""
-#     def __init__(self, meshVariable):
-#         super(variable, self).__init__()
-#         self._mesh_variable = meshVariable
-#         self.description = meshVariable._name
-#         return
-#
-#     def evaluate(self, *args, coords=None):
-#         return self._mesh_variable.evaluate(*args)
 
 class parameter(LazyEvaluation):
     """Floating point parameter / coefficient for lazy evaluation of functions"""
@@ -417,35 +211,6 @@ class parameter(LazyEvaluation):
         super(parameter, self).__init__(*args, **kwargs)
         self.value = value
         return
-
-
-    @property
-    def fn_gradient(self):
-        mesh = self._mesh
-        newLazyGradient = LazyGradientEvaluation(mesh=mesh)
-        newLazyGradient.evaluate = self.evaluate
-        newLazyGradient._fn_gradient = self._fn_gradient
-        newLazyGradient.description = "d({0})/dX,d({0})/dY".format(self.description)
-        newLazyGradient.dependency_list = self.dependency_list
-        return newLazyGradient
-
-    def _fn_gradient(self, dirn=None, mesh=None):
-        """Gradients information is not provided by default for lazy evaluation objects:
-           it is necessary to implement the gradient method"""
-
-        px = parameter(0.0)
-        px.description = "d({})/dX===0.0".format(self.description)
-        py = parameter(0.0)
-        py.description = "d({})/dY===0.0".format(self.description)
-
-        p = [px, py]
-
-        if dirn is None:
-            # not sure about dimensions here, a parameter is always 1-d so it should
-            # always return the same derivative
-            return px
-        else:
-            return p[dirn]
 
     def __call__(self, value=None):
         """Set value (X) of this parameter (equivalent to Parameter.value=X)"""
@@ -470,12 +235,5 @@ class parameter(LazyEvaluation):
         if len(args) == 1 and quagmire.mesh.check_object_is_a_q_mesh_and_raise(args[0]):
             mesh = args[0]
             return self.value * np.ones(mesh.npoints)
-
-        elif len(args) >= 1:
-            xi = np.atleast_1d(args[0])
-            yi = np.atleast_1d(args[1])
-
-            return self.value * np.ones_like(xi)
-
         else:
             return self.value

--- a/quagmire/function/misc.py
+++ b/quagmire/function/misc.py
@@ -22,16 +22,14 @@ from .function_classes import LazyEvaluation as _LazyEvaluation
 
 
 def _make_npmath_op(op, name, lazyFn):
-    newLazyFn = _LazyEvaluation(mesh=lazyFn._mesh)
+    newLazyFn = _LazyEvaluation()
     newLazyFn.evaluate = lambda *args, **kwargs : op(lazyFn.evaluate(*args, **kwargs))
-    newLazyFn.gradient = lambda *args, **kwargs : op(lazyFn.gradient(*args, **kwargs))
     newLazyFn.description = "{}({})".format(name, lazyFn.description)
     newLazyFn.dependency_list = lazyFn.dependency_list
 
     return newLazyFn
 
 ## Trig
-
 def coord(dirn):
 
     def extract_xs(*args, **kwargs):
@@ -57,11 +55,11 @@ def coord(dirn):
             return args[1]
 
 
-    newLazyFn_xs = _LazyEvaluation(mesh=None)
+    newLazyFn_xs = _LazyEvaluation()
     newLazyFn_xs.evaluate = extract_xs
     newLazyFn_xs.description = "X"
 
-    newLazyFn_ys = _LazyEvaluation(mesh=None)
+    newLazyFn_ys = _LazyEvaluation()
     newLazyFn_ys.evaluate = extract_ys
     newLazyFn_ys.description = "Y"
 
@@ -73,7 +71,7 @@ def coord(dirn):
 
 def levelset(lazyFn, alpha=0.5, invert=False):
 
-    newLazyFn = _LazyEvaluation(mesh=lazyFn._mesh)
+    newLazyFn = _LazyEvaluation()
 
     def threshold(*args, **kwargs):
         if not invert:
@@ -95,7 +93,7 @@ def levelset(lazyFn, alpha=0.5, invert=False):
 
 def maskNaN(lazyFn, invert=False):
 
-    newLazyFn = _LazyEvaluation(mesh=lazyFn._mesh)
+    newLazyFn = _LazyEvaluation()
 
     def threshold(*args, **kwargs):
         if invert:
@@ -126,7 +124,7 @@ def replaceNan(lazyFn1, lazyFn2):
         replaced_values  = _np.where(mask_values, values2, values1)
         return replaced_values
 
-    newLazyFn = _LazyEvaluation(mesh=lazyFn1._mesh)
+    newLazyFn = _LazyEvaluation()
     newLazyFn.evaluate = replaceNan_nodebynode
     newLazyFn.description = "Nan([{}]<-[{}])".format(lazyFn1.description, lazyFn2.description)
     newLazyFn.dependency_list = lazyFn1.dependency_list | lazyFn2.dependency_list
@@ -144,7 +142,7 @@ def where(maskFn, lazyFn1, lazyFn2):
         replaced_values  = _np.where(mask_values < 0.5, values1, values2)
         return replaced_values
 
-    newLazyFn = _LazyEvaluation(mesh=lazyFn1._mesh)
+    newLazyFn = _LazyEvaluation()
     newLazyFn.evaluate = mask_nodebynode
     newLazyFn.description = "where({}: [{}]<-[{}])".format(maskFn.description, lazyFn1.description, lazyFn2.description)
     newLazyFn.dependency_list = maskFn.dependency_list |     lazyFn1.dependency_list | lazyFn2.dependency_list

--- a/quagmire/function/stats.py
+++ b/quagmire/function/stats.py
@@ -42,9 +42,8 @@ def _all_reduce(array, name):
     return garray
 
 def _make_reduce_op(name, lazyFn):
-    newLazyFn = _LazyEvaluation(mesh=lazyFn._mesh)
+    newLazyFn = _LazyEvaluation()
     newLazyFn.evaluate = lambda *args, **kwargs : _all_reduce(lazyFn.evaluate(*args, **kwargs), name)
-    newLazyFn.gradient = lambda *args, **kwargs : _all_reduce(lazyFn.gradient(*args, **kwargs), name)
     newLazyFn.description = "{}({})".format(name, lazyFn.description)
     newLazyFn.dependency_list = lazyFn.dependency_list
     return newLazyFn

--- a/quagmire/mesh/basemesh.py
+++ b/quagmire/mesh/basemesh.py
@@ -282,8 +282,12 @@ class MeshVariable(_LazyEvaluation):
         self._dm.globalToLocal(gdata, self._ldata)
         self._dm.restoreGlobalVec(gdata)
 
+    @property
+    def fn_gradient(self):
+        return self._fn_gradient()
 
-    def fn_gradient(self, nit=10, tol=1e-8):
+    def _fn_gradient(self, nit=10, tol=1e-8):
+
         """
         Compute values of the derivatives of PHI in the x, y directions at the nodal points.
         This routine uses SRFPACK to compute derivatives on a C-1 bivariate function.
@@ -303,6 +307,7 @@ class MeshVariable(_LazyEvaluation):
         PHIy : ndarray of floats, shape (n,)
             first partial derivative of PHI in y direction
         """
+
         import quagmire
 
         class _gradient(_LazyEvaluation):
@@ -331,10 +336,8 @@ class MeshVariable(_LazyEvaluation):
                 return self
 
 
-        self._fn_gradient = _gradient(self, nit, tol)
+        return _gradient(self, nit, tol)
         
-        return self._fn_gradient
-
 
     def gradient_patch(self):
 

--- a/quagmire/mesh/basemesh.py
+++ b/quagmire/mesh/basemesh.py
@@ -28,6 +28,7 @@ except: pass
 ## These also need to be lazy evaluation objects
 
 from ..function import LazyEvaluation as _LazyEvaluation
+import numpy as np
 
 
 
@@ -282,7 +283,7 @@ class MeshVariable(_LazyEvaluation):
         self._dm.restoreGlobalVec(gdata)
 
 
-    def gradient(self, nit=10, tol=1e-8):
+    def fn_gradient(self, nit=10, tol=1e-8):
         """
         Compute values of the derivatives of PHI in the x, y directions at the nodal points.
         This routine uses SRFPACK to compute derivatives on a C-1 bivariate function.
@@ -302,13 +303,41 @@ class MeshVariable(_LazyEvaluation):
         PHIy : ndarray of floats, shape (n,)
             first partial derivative of PHI in y direction
         """
+        import quagmire
 
-        dx, dy = self._mesh.derivative_grad(self._ldata.array, nit, tol)
+        class _gradient(_LazyEvaluation):
+        
+            def __init__(self, meshVariable, nit, tol, *args, **kwargs):
+                super(_gradient, self).__init__()
+                ldata = meshVariable._ldata.array
+                self._mesh = meshVariable._mesh
+                self.grads = meshVariable._mesh.derivative_grad(ldata, nit=nit, tol=tol)
+                return
 
-        return dx, dy
+            def __getitem__(self, item):
+                def func(*args):
+                    if args:
+                        if args[0] == self._mesh:
+                            return self.grads[:, item]
+                        elif isinstance(args[0], (quagmire.mesh.trimesh.TriMesh, quagmire.mesh.pixmesh.PixMesh) ):
+                            mesh = args[0]
+                            return self._mesh.interpolate(mesh.coords[:,0], mesh.coords[:,1], zdata=self.grads[:,item])[0]
+                        else:
+                            coords = args[0]
+                            return self._mesh.interpolate(coords[0], coords[1], zdata=self.grads[:, item])[0]
+                    else:
+                        return self.grads[:, item]
+                self.evaluate = func
+                return self
+
+
+        self._fn_gradient = _gradient(self, nit, tol)
+        
+        return self._fn_gradient
 
 
     def gradient_patch(self):
+
         """
         Compute values of the derivatives of PHI in the x, y directions at the nodal points.
         This routine uses SRFPACK to compute derivatives on a C-1 bivariate function.
@@ -404,7 +433,7 @@ class MeshVariable(_LazyEvaluation):
             return i
 
 
-    def evaluate(self, *args, **kwargs):
+    def evaluate(self, input=None, **kwargs):
         """
         If the argument is a mesh, return the values at the nodes.
         In all other cases call the `interpolate` method.
@@ -412,14 +441,20 @@ class MeshVariable(_LazyEvaluation):
 
         import quagmire
 
-        if len(args) == 1 and args[0] == self._mesh:
-            return self._ldata.array
-        elif len(args) == 1 and isinstance(args[0], (quagmire.mesh.trimesh.TriMesh, quagmire.mesh.pixmesh.PixMesh) ):
-            mesh = args[0]
-            return self.interpolate(mesh.coords[:,0], mesh.coords[:,1], **kwargs)
+        if input is not None:
+            if isinstance(input, (quagmire.mesh.trimesh.TriMesh, 
+                                  quagmire.mesh.pixmesh.PixMesh,
+                                  quagmire.mesh.strimesh.sTriMesh)):
+                if input == self._mesh:
+                    return self._ldata.array
+                else:
+                    return self.interpolate(input.coords[:,0], input.coords[:,1], **kwargs)
+            elif isinstance(input, (tuple, list, np.ndarray)):
+                input = np.array(input)
+                input = np.reshape(input, (-1, 2))
+                return self.interpolate(input[:, 0], input[:,1], **kwargs)
         else:
-            return self.interpolate(*args, **kwargs)
-
+            return self._ldata.array
 
 
     ## Basic global operations provided by petsc4py

--- a/tests/test_2_mesh_variables.py
+++ b/tests/test_2_mesh_variables.py
@@ -38,6 +38,32 @@ def test_mesh_variable_instance(DM):
 
     return
 
+
+def test_mesh_variable_evaluation_1(DM):
+    mesh = QuagMesh(DM, downhill_neighbours=1)
+    meshVar = mesh.add_variable(name="meshVar")
+    results = meshVar.evaluate()
+    assert(results.size == mesh.data[:, 0].size)
+
+def test_mesh_variable_evaluation_2(DM):
+    mesh = QuagMesh(DM, downhill_neighbours=1)
+    meshVar = mesh.add_variable(name="meshVar")
+    results = meshVar.evaluate([0.,0.])
+    assert(results.size == 1)
+
+def test_mesh_variable_evaluation_3(DM):
+    mesh = QuagMesh(DM, downhill_neighbours=1)
+    meshVar = mesh.add_variable(name="meshVar")
+    results = meshVar.evaluate(mesh)
+    assert(results.size == mesh.data[:, 0].size)
+
+def test_mesh_variable_evaluation_4(DM):
+    mesh = QuagMesh(DM, downhill_neighbours=1)
+    mesh2 = QuagMesh(DM, downhill_neighbours=1)
+    meshVar = mesh.add_variable(name="meshVar")
+    results = meshVar.evaluate(mesh2)
+    assert(results.size == mesh.data[:, 0].size)
+
 def test_mesh_variable_properties(DM):
 
     mesh = QuagMesh(DM, downhill_neighbours=1)

--- a/tests/test_2_mesh_variables.py
+++ b/tests/test_2_mesh_variables.py
@@ -29,8 +29,8 @@ def test_mesh_variable_instance(DM):
     assert np.isclose(phi.interpolate(0.01,1.0), 1.0)
     assert np.isclose(psi.interpolate(0.01,1.0), 1.0)
 
-    assert np.isclose(phi.evaluate(0.01,1.0),    1.0)
-    assert np.isclose(psi.evaluate(0.01,1.0),    1.0)
+    assert np.isclose(phi.evaluate([0.01,1.0]),    1.0)
+    assert np.isclose(psi.evaluate([0.01,1.0]),    1.0)
 
     ## This is the alternate interface to access the same code
 
@@ -83,7 +83,7 @@ def test_mesh_variable_derivative(DM):
     phi.data = np.sin(mesh.coords[:,0])
     psi.data = np.cos(mesh.coords[:,0])
 
-    assert(np.isclose(phi.fn_gradient[0].evaluate(0.0,0.0), psi.evaluate(0.0,0.0), rtol=0.01))
+    assert(np.isclose(phi.fn_gradient()[0].evaluate([0.0,0.0]), psi.evaluate([0.0,0.0]), rtol=0.01))
 
 
     return

--- a/tests/test_2_mesh_variables.py
+++ b/tests/test_2_mesh_variables.py
@@ -83,7 +83,7 @@ def test_mesh_variable_derivative(DM):
     phi.data = np.sin(mesh.coords[:,0])
     psi.data = np.cos(mesh.coords[:,0])
 
-    assert(np.isclose(phi.fn_gradient()[0].evaluate([0.0,0.0]), psi.evaluate([0.0,0.0]), rtol=0.01))
+    assert(np.isclose(phi.fn_gradient[0].evaluate([0.0,0.0]), psi.evaluate([0.0,0.0]), rtol=0.01))
 
 
     return

--- a/tests/test_3_quagmire_functions.py
+++ b/tests/test_3_quagmire_functions.py
@@ -24,15 +24,14 @@ def test_parameters():
     ## And this is how to update A
 
     A.value = 100.0
-    assert fn.math.exp(A).evaluate(0.0,0.0) == np.exp(100.0)
+    assert fn.math.exp(A).evaluate() == np.exp(100.0)
 
     ## This works too ... and note the floating point conversion
     A(101)
-    assert fn.math.exp(A).evaluate(0.0,0.0) == np.exp(101.0)
+    assert fn.math.exp(A).evaluate() == np.exp(101.0)
 
     ## More complicated examples
-    assert (fn.math.sin(A)**2.0 + fn.math.cos(A)**2.0).evaluate(0.0,0.0) == 1.0
-
+    assert (fn.math.sin(A)**2.0 + fn.math.cos(A)**2.0).evaluate() == 1.0
 
 
 def test_fn_description():

--- a/tests/test_5_FlatMesh_object.py
+++ b/tests/test_5_FlatMesh_object.py
@@ -15,8 +15,8 @@ def test_derivatives_and_interpolation(DM):
     height = mesh.add_variable(name="h(x,y)")
     height.data = mesh.coords[:,0]**2 + mesh.coords[:,1]**2
 
-    dhdx = height.fn_gradient()[0]
-    dhdy = height.fn_gradient()[1]
+    dhdx = height.fn_gradient[0]
+    dhdy = height.fn_gradient[1]
 
     dhdx.evaluate()
     dhdx.evaluate()

--- a/tests/test_5_FlatMesh_object.py
+++ b/tests/test_5_FlatMesh_object.py
@@ -15,15 +15,18 @@ def test_derivatives_and_interpolation(DM):
     height = mesh.add_variable(name="h(x,y)")
     height.data = mesh.coords[:,0]**2 + mesh.coords[:,1]**2
 
-    dhdx = height.fn_gradient[0]
-    dhdy = height.fn_gradient[1]
+    dhdx = height.fn_gradient()[0]
+    dhdy = height.fn_gradient()[1]
+
+    dhdx.evaluate()
+    dhdx.evaluate()
 
     # interpolate onto a straight line
     # bounding box should be [-5,5,-5,5]
     xy_pts = np.linspace(0,3,10)
 
-    interp_x = dhdx.evaluate(xy_pts, xy_pts)
-    interp_y = dhdy.evaluate(xy_pts, xy_pts)
+    interp_x = dhdx.evaluate([xy_pts, xy_pts])
+    interp_y = dhdy.evaluate([xy_pts, xy_pts])
 
     ascending_x = ( np.diff(interp_x) > 0 ).all()
     ascending_y = ( np.diff(interp_y) > 0 ).all()

--- a/tests/test_6_TopoMesh_object.py
+++ b/tests/test_6_TopoMesh_object.py
@@ -127,12 +127,15 @@ def test_streamwise_smoothing(DM):
     rainfall = mesh.add_variable("rainfall")
     rainfall.data = np.random.random(size=mesh.npoints)
 
-    sm1 = np.std(rainfall.evaluate(stream_x, stream_y))
+    stream = np.ndarray((stream_x.size, 2))
+    stream[:, 0] = stream_x
+    stream[:, 1] = stream_y
+    sm1 = np.std(rainfall.evaluate(stream))
 
     for i in range(1,4):
         sm0 = float(sm1)
         smooth_fn = mesh.streamwise_smoothing_fn(rainfall, its=i)
-        sm1 = np.std(smooth_fn.evaluate(stream_x, stream_y))
+        sm1 = np.std(smooth_fn.evaluate(stream))
 
         assert sm1 < sm0, "{}: streamwise smoothing at its={} no smoother than its={}".format(mesh.id, i, i-1)
 


### PR DESCRIPTION
1. Remove mesh from LazyEvaluation class
2. fn_gradient method is only available from the MeshVariable class.
3. Change arg name LazyFn to MeshVar where appropriate
4. Change shape of array returned by the `derivative_grad` methods. (All
   meshes). This to be consistent with the shape of `mesh.data`. Also
   consistent with Underworld.
5. Evaluation on coordinates requires passing a list, or numpy array of
   shape (n, 2). Again this is for consistency with UW...
6. Update tests to account for changes. All tests passing.